### PR TITLE
Total users metrics shouldn't be separated into weeks for USSD app

### DIFF
--- a/js_sandbox/lib/go-nike-ghr.js
+++ b/js_sandbox/lib/go-nike-ghr.js
@@ -524,7 +524,7 @@ function GoNikeGHR() {
                         contact_key = result.contact.key;
                         if (result.contact["extras-ghr_last_active_week"] !== undefined){
                             if (new Date(wc) > new Date(result.contact["extras-ghr_last_active_week"])){
-                                var piafd = self.increment_and_fire_direct("ghr_ussd_total_users_"+wc);
+                                var piafd = self.increment_and_fire_direct("ghr_ussd_total_users");
                                 piafd.add_callback(function(result) {
                                     return true;
                                 });

--- a/js_sandbox/test/test-go-nike-ghr.js
+++ b/js_sandbox/test/test-go-nike-ghr.js
@@ -442,7 +442,7 @@ describe("When using the USSD line", function() {
                     "5. Directory$"
             });
             p.then(function() {
-                var updated_kv = tester.api.kv_store['ghr_ussd_total_users_2013-05-27'];
+                var updated_kv = tester.api.kv_store['ghr_ussd_total_users'];
                 assert.equal(updated_kv, 1);
             }).then(done, done);
         });


### PR DESCRIPTION
It looks like the ghr ussd js app is separating the metrics fired for users into weeks (the metric looks something like `ghr_ussd_total_users_<week>`). I think this needs to be changed to simply increment the total users (so the name should like something like `ghr_ussd_total_users`). The app does not have to worry about splitting up the metrics into different weeks, diamondash and graphite will handle this.

https://github.com/praekelt/go-nike-ghr/blob/develop/js_sandbox/lib/go-nike-ghr.js#L532
