### PR TITLE
Refresh i18n in initial state

### DIFF
--- a/js_sandbox/lib/go-nike-ghr.js
+++ b/js_sandbox/lib/go-nike-ghr.js
@@ -1032,12 +1032,16 @@ function GoNikeGHR() {
     };
 
     self.add_creator('initial_state', function(state_name, im) {
+        im.set_user_lang('rw');
+        var p = im.refresh_i18n();
+
         // Check if they've already registered
-        var p = self.get_contact(im);
+        p.add_callback(function() {
+          return self.get_contact(im);
+        });
 
         p.add_callback(function(result) {
             // This callback creates extras if first time visitor - or just passes through
-            im.set_user_lang('rw')
             if (result.contact["extras-ghr_reg_complete"] === undefined){
                 // First visit - create extras
                 var today = self.get_today(im);


### PR DESCRIPTION
At the moment, we set the user's language in the initial state to Kinyarwanda before replying using `im.set_user_lang`, but don't call `.refresh_i18n` after doing this. This means that new users and users that entered '!restart' will see the first state in English (the default language) instead of Kinyarwanda.
